### PR TITLE
Prevent getting timeouts during bot start

### DIFF
--- a/bot/delete_log.py
+++ b/bot/delete_log.py
@@ -56,7 +56,7 @@ class DeleteLogVoteSession(AbstractVoteSession):
     async def _async_init(self) -> None:
         """Track the vote session in the database."""
         self.id = await track_vote_session(
-            self._messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold
+            await self.fetch_messages(), self.author_id, self.kind, self.pass_threshold, self.fail_threshold
         )
         await track_delete_log_vote_session(self.id, self.target_message)
         await self.update_messages()
@@ -98,7 +98,7 @@ class DeleteLogVoteSession(AbstractVoteSession):
     async def create(
         cls,
         bot: discord.Client,
-        messages: list[discord.Message],
+        messages: list[discord.Message] | list[int],
         author_id: int,
         target_message: discord.Message,
         pass_threshold: int = 3,

--- a/bot/submission/submit.py
+++ b/bot/submission/submit.py
@@ -52,7 +52,7 @@ class BuildVoteSession(AbstractVoteSession):
     def __init__(
         self,
         bot: discord.Client,
-        messages: list[discord.Message],
+        messages: list[discord.Message] | list[int],
         author_id: int,
         build: Build,
         pass_threshold: int = 3,
@@ -76,7 +76,7 @@ class BuildVoteSession(AbstractVoteSession):
     async def _async_init(self) -> None:
         """Track the vote session in the database."""
         self.id = await track_vote_session(
-            self._messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold, build_id=self.build.id
+            await self.fetch_messages(), self.author_id, self.kind, self.pass_threshold, self.fail_threshold, build_id=self.build.id
         )
         await self.update_messages()
 
@@ -131,7 +131,7 @@ class BuildVoteSession(AbstractVoteSession):
     async def create(
         cls,
         bot: discord.Client,
-        messages: list[discord.Message],
+        messages: list[discord.Message] | list[int],
         author_id: int,
         build: Build,
         pass_threshold: int = 3,

--- a/bot/submission/submit.py
+++ b/bot/submission/submit.py
@@ -708,7 +708,7 @@ async def setup(bot: "RedstoneSquid"):
     cog = SubmissionsCog(bot)
     open_vote_sessions = await BuildVoteSession.get_open_vote_sessions(bot)
     for session in open_vote_sessions:
-        for message in session._messages:
-            cog.open_vote_sessions[message.id] = session
+        for message_id in session.message_ids:
+            cog.open_vote_sessions[message_id] = session
 
     await bot.add_cog(cog)

--- a/bot/submission/submit.py
+++ b/bot/submission/submit.py
@@ -51,6 +51,7 @@ class BuildVoteSession(AbstractVoteSession):
 
     def __init__(
         self,
+        bot: discord.Client,
         messages: list[discord.Message],
         author_id: int,
         build: Build,
@@ -61,25 +62,26 @@ class BuildVoteSession(AbstractVoteSession):
         Initialize the vote session.
 
         Args:
+            bot: The discord client.
             messages: The messages belonging to the vote session.
             author_id: The discord id of the author of the vote session.
             build: The build which the vote session is for.
             pass_threshold: The number of votes required to pass the vote.
             fail_threshold: The number of votes required to fail the vote.
         """
-        super().__init__(messages, author_id, pass_threshold, fail_threshold)
+        super().__init__(bot, messages, author_id, pass_threshold, fail_threshold)
         self.build = build
 
     @override
     async def _async_init(self) -> None:
         """Track the vote session in the database."""
         self.id = await track_vote_session(
-            self.messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold, build_id=self.build.id
+            self._messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold, build_id=self.build.id
         )
         await self.update_messages()
 
-        reaction_tasks = [message.add_reaction(APPROVE_EMOJIS[0]) for message in self.messages]
-        reaction_tasks.extend([message.add_reaction(DENY_EMOJIS[0]) for message in self.messages])
+        reaction_tasks = [message.add_reaction(APPROVE_EMOJIS[0]) for message in self._messages]
+        reaction_tasks.extend([message.add_reaction(DENY_EMOJIS[0]) for message in self._messages])
         try:
             await asyncio.gather(*reaction_tasks)
         except discord.Forbidden:
@@ -104,8 +106,6 @@ class BuildVoteSession(AbstractVoteSession):
 
         vote_session_record = vote_session_response.data
 
-        messages = await asyncio.gather(*[utils.getch(bot, msg) for msg in vote_session_record["messages"]])
-
         build_id = vote_session_record["build_vote_sessions"]["build_id"]
         build = await Build.from_id(build_id)
         if build is None:
@@ -116,7 +116,8 @@ class BuildVoteSession(AbstractVoteSession):
         self = cls.__new__(cls)
         self._allow_init = True
         self.__init__(
-            messages,
+            bot,
+            [record["message_id"] for record in vote_session_record["messages"]],
             vote_session_record["author_id"],
             build,
             vote_session_record["pass_threshold"],
@@ -129,13 +130,14 @@ class BuildVoteSession(AbstractVoteSession):
     @override
     async def create(
         cls,
+        bot: discord.Client,
         messages: list[discord.Message],
         author_id: int,
         build: Build,
         pass_threshold: int = 3,
         fail_threshold: int = -3,
     ) -> "BuildVoteSession":
-        self = await super().create(messages, author_id, build, pass_threshold, fail_threshold)
+        self = await super().create(bot, messages, author_id, build, pass_threshold, fail_threshold)
         assert isinstance(self, BuildVoteSession)
         return self
 
@@ -143,7 +145,7 @@ class BuildVoteSession(AbstractVoteSession):
     async def send_message(self, channel: discord.abc.Messageable) -> discord.Message:
         message = await channel.send(embed=self.build.generate_embed())
         await msg.track_message(message, purpose="vote", build_id=self.build.id, vote_session_id=self.id)
-        self.messages.append(message)
+        self._messages.append(message)
         return message
 
     @override
@@ -151,7 +153,7 @@ class BuildVoteSession(AbstractVoteSession):
         embed = self.build.generate_embed()
         embed.add_field(name="upvotes", value=str(self.upvotes), inline=True)
         embed.add_field(name="downvotes", value=str(self.downvotes), inline=True)
-        await asyncio.gather(*[message.edit(embed=embed) for message in self.messages])
+        await asyncio.gather(*[message.edit(embed=embed) for message in await self.fetch_messages()])
 
     @override
     async def close(self) -> None:
@@ -164,6 +166,8 @@ class BuildVoteSession(AbstractVoteSession):
         else:
             await self.build.confirm()
         # TODO: decide whether to delete the messages or not
+
+        await self.update_messages()
 
         if self.id is not None:
             await close_vote_session(self.id)
@@ -181,8 +185,6 @@ class BuildVoteSession(AbstractVoteSession):
         ).data
 
         async def _get_session(record: dict[str, Any]) -> "BuildVoteSession":
-            messages = await asyncio.gather(*[utils.getch(bot, msg) for msg in record["messages"]])
-
             build_id: int = record["build_vote_sessions"]["build_id"]
             build = await Build.from_id(build_id)
 
@@ -190,7 +192,8 @@ class BuildVoteSession(AbstractVoteSession):
             session = cls.__new__(cls)
             session._allow_init = True
             session.__init__(
-                messages,
+                bot,
+                [msg["message_id"] for msg in record["messages"]],
                 record["author_id"],
                 build,
                 record["pass_threshold"],
@@ -447,7 +450,7 @@ class SubmissionsCog(Cog, name="Submissions"):
         messages = await asyncio.gather(*tasks)
 
         assert build.submitter_id is not None
-        session = await BuildVoteSession.create(messages, build.submitter_id, build)
+        session = await BuildVoteSession.create(self.bot, messages, build.submitter_id, build)
         for message in messages:
             self.open_vote_sessions[message.id] = session
 
@@ -705,7 +708,7 @@ async def setup(bot: "RedstoneSquid"):
     cog = SubmissionsCog(bot)
     open_vote_sessions = await BuildVoteSession.get_open_vote_sessions(bot)
     for session in open_vote_sessions:
-        for message in session.messages:
+        for message in session._messages:
             cog.open_vote_sessions[message.id] = session
 
     await bot.add_cog(cog)

--- a/bot/vote_session.py
+++ b/bot/vote_session.py
@@ -8,13 +8,16 @@ import asyncio
 from asyncio import Task
 from dataclasses import dataclass
 from types import MethodType
-from typing import Any, TypeVar, Union, TYPE_CHECKING
+from typing import Any, TypeVar, Union, TYPE_CHECKING, cast
 
 import discord
+from postgrest import APIResponse
 
+from bot import utils
 from bot._types import GuildMessageable
+from database import DatabaseManager
 from database.builds import Build
-from database.schema import VoteKind
+from database.schema import VoteKind, MessageRecord
 from database.vote import close_vote_session, track_vote_session, upsert_vote
 
 if TYPE_CHECKING:
@@ -44,14 +47,15 @@ class AbstractVoteSession(ABC):
 
     kind: VoteKind
 
-    def __init__(self, messages: list[discord.Message], author_id: int, pass_threshold: int, fail_threshold: int):
+    def __init__(self, bot: discord.Client, messages: list[discord.Message] | list[int], author_id: int, pass_threshold: int, fail_threshold: int):
         """
         Initialize the vote session, this should be called by subclasses only. Use create() instead.
 
         If you use this constructor directly, you must call _async_init() afterwards, or else the vote session will not be tracked.
 
         Args:
-            messages: The messages belonging to the vote session.
+            bot: The discord client for fetching messages.
+            messages: The messages (or their ids) belonging to the vote session.
             author_id: The discord id of the author of the vote session.
             pass_threshold: The number of votes required to pass the vote.
             fail_threshold: The number of votes required to fail the vote.
@@ -65,7 +69,17 @@ class AbstractVoteSession(ABC):
         self.id: int | None = None
         """The id of the vote session in the database. If None, we are not tracking the vote session and thus no async operations are performed."""
         self.is_closed = False
-        self.messages = messages
+        self.bot = bot
+        self._messages: list[discord.Message]
+        self.message_ids: list[int]
+        if all(isinstance(message, int) for message in messages):
+            messages = cast(list[int], messages)
+            self._messages = []
+            self.message_ids = messages
+        else:
+            messages = cast(list[discord.Message], messages)
+            self._messages = messages
+            self.message_ids = [message.id for message in messages]
         if len(messages) >= 10:
             raise ValueError(
                 "Found a vote session with more than 10 messages, we need to change the update_message logic."
@@ -80,7 +94,7 @@ class AbstractVoteSession(ABC):
     async def _async_init(self) -> None:
         """Perform async initialization. Called by create()."""
         self.id = await track_vote_session(
-            self.messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold
+            self._messages, self.author_id, self.kind, self.pass_threshold, self.fail_threshold
         )
         await self.update_messages()
 
@@ -133,7 +147,7 @@ class AbstractVoteSession(ABC):
 
     @classmethod
     @abstractmethod
-    async def from_id(cls: type[T], bot: RedstoneSquid, vote_session_id: int) -> Union[T, None]:
+    async def from_id(cls: type[T], bot: discord.Client, vote_session_id: int) -> Union[T, None]:
         """
         Create a vote session from an id.
 
@@ -163,6 +177,23 @@ class AbstractVoteSession(ABC):
     @abstractmethod
     async def send_message(self, channel: discord.abc.Messageable) -> discord.Message:
         """Send a vote session message to a channel"""
+
+    async def get_messages(self) -> list[discord.Message] | None:
+        """Get the messages of the vote session if they exist in the cache"""
+        if len(self.message_ids) == len(self._messages):
+            return self._messages
+
+    async def fetch_messages(self) -> list[discord.Message]:
+        """Fetch the messages of the vote session"""
+        if len(self.message_ids) == len(self._messages):
+            return self._messages
+
+        messages_record: APIResponse[MessageRecord] = await DatabaseManager().table("messages").select("*").in_("message_id", self.message_ids).execute()
+        cached_ids = {message.id for message in self._messages}
+        new_messages = await asyncio.gather(*(utils.getch(self.bot, record) for record in messages_record.data if record["message_id"] not in cached_ids))
+        self._messages.extend(new_messages)
+        assert len(self._messages) == len(self.message_ids)
+        return self._messages
 
     @abstractmethod
     async def update_messages(self) -> None:

--- a/database/builds.py
+++ b/database/builds.py
@@ -280,8 +280,6 @@ class Build:
             bot: A bot instance to get the channels from.
         """
 
-        target: ChannelPurpose
-
         target: Literal["Smallest", "Fastest", "First", "Builds", "Vote"]
 
         match (self.submission_status, self.record_category):

--- a/database/message.py
+++ b/database/message.py
@@ -31,15 +31,6 @@ async def get_build_messages(build_id: int) -> list[MessageRecord]:
     return response.data
 
 
-async def get_messages(server_id: int, build_id: int) -> list[MessageRecord]:
-    """Get the unique message for a build in a server"""
-    db = DatabaseManager()
-    server_record: APIResponse[MessageRecord] = (
-        await db.table("messages").select("*").eq("server_id", server_id).eq("build_id", build_id).execute()
-    )
-    return server_record.data
-
-
 async def track_message(
     message: discord.Message,
     purpose: MessagePurpose,


### PR DESCRIPTION
Just fetching ~10 messages in 1 second is already making discord unhappy lol, so we don't initialize VoteSessions with the message object but rather just the ids