### PR TITLE
Add an application level lock to editing builds

### DIFF
--- a/squid/bot/__init__.py
+++ b/squid/bot/__init__.py
@@ -103,6 +103,10 @@ def setup_logging():
     logger = logging.getLogger("discord")
     logger.setLevel(logging.INFO)
 
+    if DEV_MODE:
+        # dpy emits heartbeat warning whenever you suspend the bot for over 10 seconds, which is annoying if you attach a debugger
+        logging.getLogger("discord.gateway").setLevel(logging.ERROR)
+
     file_handler = RotatingFileHandler(
         filename="discord.log",
         encoding="utf-8",

--- a/squid/bot/submission/edit.py
+++ b/squid/bot/submission/edit.py
@@ -176,7 +176,7 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 error_embed = utils.error_embed("Error", "No build with that ID.")
                 return await sent_message.edit(embed=error_embed)
 
-            if not await build.try_acquire_lock():
+            if not await build.lock.try_lock():
                 return await sent_message.edit(
                     embed=utils.error_embed("Error", "Build is currently being edited by someone else.")
                 )
@@ -197,20 +197,20 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 await preview.delete()
                 if view.value is None:
                     await asyncio.gather(
-                        build.release_lock(),
+                        build.lock.release_lock(),
                         sent_message.edit(embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")),
                     )
                     return
                 elif view.value is False:
                     await asyncio.gather(
-                        build.release_lock(),
+                        build.lock.release_lock(),
                         sent_message.edit(embed=utils.info_embed("Cancelled", "Build edit canceled by user")),
                     )
                     return
 
             await sent_message.edit(embed=utils.info_embed("Editing", "Editing build..."))
             await build.save()
-            await build.release_lock()
+            await build.lock.release_lock()
             await self.bot.for_build(build).update_messages()
             await sent_message.edit(embed=utils.info_embed("Success", "Build edited successfully"))
 

--- a/squid/bot/submission/edit.py
+++ b/squid/bot/submission/edit.py
@@ -176,7 +176,7 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 error_embed = utils.error_embed("Error", "No build with that ID.")
                 return await sent_message.edit(embed=error_embed)
 
-            if not await build.lock.try_lock():
+            if not await build.lock.acquire(blocking=False):
                 return await sent_message.edit(
                     embed=utils.error_embed("Error", "Build is currently being edited by someone else.")
                 )
@@ -197,20 +197,20 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 await preview.delete()
                 if view.value is None:
                     await asyncio.gather(
-                        build.lock.release_lock(),
+                        build.lock.release(),
                         sent_message.edit(embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")),
                     )
                     return
                 elif view.value is False:
                     await asyncio.gather(
-                        build.lock.release_lock(),
+                        build.lock.release(),
                         sent_message.edit(embed=utils.info_embed("Cancelled", "Build edit canceled by user")),
                     )
                     return
 
             await sent_message.edit(embed=utils.info_embed("Editing", "Editing build..."))
             await build.save()
-            await build.lock.release_lock()
+            await build.lock.release()
             await self.bot.for_build(build).update_messages()
             await sent_message.edit(embed=utils.info_embed("Success", "Build edited successfully"))
 

--- a/squid/bot/submission/edit.py
+++ b/squid/bot/submission/edit.py
@@ -198,7 +198,9 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 if view.value is None:
                     await asyncio.gather(
                         build.lock.release(),
-                        sent_message.edit(embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")),
+                        sent_message.edit(
+                            embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")
+                        ),
                     )
                     return
                 elif view.value is False:

--- a/squid/bot/submission/edit.py
+++ b/squid/bot/submission/edit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Literal
 
 import discord
@@ -175,15 +176,19 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 error_embed = utils.error_embed("Error", "No build with that ID.")
                 return await sent_message.edit(embed=error_embed)
 
-            preview_embed = await self.bot.for_build(build).generate_embed()
+            if not await build.try_acquire_lock():
+                return await sent_message.edit(
+                    embed=utils.error_embed("Error", "Build is currently being edited by someone else.")
+                )
 
-            # Show a preview of the changes and ask for confirmation
-            await sent_message.edit(embed=utils.info_embed("Waiting", "User confirming changes..."))
+            # If in a slash command, we show a preview and ask for confirmation, otherwise we just edit the build
             if ctx.interaction:
+                # Show a preview of the changes and ask for confirmation
+                await sent_message.edit(embed=utils.info_embed("Waiting", "User confirming changes..."))
                 view = ConfirmationView()
                 preview = await ctx.interaction.followup.send(
                     "Here is a preview of the changes. Use the buttons to confirm or cancel.",
-                    embed=preview_embed,
+                    embed=await self.bot.for_build(build).generate_embed(),
                     view=view,
                     ephemeral=True,
                     wait=True,
@@ -191,21 +196,23 @@ class BuildEditCog[BotT: RedstoneSquid](Cog):
                 await view.wait()
                 await preview.delete()
                 if view.value is None:
-                    await sent_message.edit(
-                        embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")
+                    await asyncio.gather(
+                        build.release_lock(),
+                        sent_message.edit(embed=utils.info_embed("Timed out", "Build edit canceled due to inactivity.")),
                     )
-                elif view.value:
-                    await sent_message.edit(embed=utils.info_embed("Editing", "Editing build..."))
-                    await build.save()
-                    await self.bot.for_build(build).update_messages()
-                    await sent_message.edit(embed=utils.info_embed("Success", "Build edited successfully"))
-                else:
-                    await sent_message.edit(embed=utils.info_embed("Cancelled", "Build edit canceled by user"))
-            else:  # Not an interaction, so we can't use buttons for confirmation
-                await sent_message.edit(embed=utils.info_embed("Editing", "Editing build..."))
-                await build.save()
-                await self.bot.for_build(build).update_messages()
-                await sent_message.edit(embed=utils.info_embed("Success", "Build edited successfully"))
+                    return
+                elif view.value is False:
+                    await asyncio.gather(
+                        build.release_lock(),
+                        sent_message.edit(embed=utils.info_embed("Cancelled", "Build edit canceled by user")),
+                    )
+                    return
+
+            await sent_message.edit(embed=utils.info_embed("Editing", "Editing build..."))
+            await build.save()
+            await build.release_lock()
+            await self.bot.for_build(build).update_messages()
+            await sent_message.edit(embed=utils.info_embed("Success", "Build edited successfully"))
 
     async def edit_context_menu(self, interaction: discord.Interaction[BotT], message: discord.Message) -> None:
         """A context menu command to edit a build."""

--- a/squid/bot/submission/ui/components.py
+++ b/squid/bot/submission/ui/components.py
@@ -12,7 +12,6 @@ from beartype.door import is_bearable
 from discord import Interaction, TextStyle
 from discord.ui import Item
 
-from squid.bot.submission import ui
 from squid.bot.submission.parse import get_formatter_and_parser_for_type
 from squid.db.builds import Build
 from squid.db.schema import DOOR_ORIENTATION_NAMES, RECORD_CATEGORIES
@@ -224,12 +223,7 @@ class DynamicBuildEditButton[BotT: RedstoneSquid, V: discord.ui.View](
 
     @override
     async def callback(self, interaction: Interaction[BotT]) -> Any:  # pyright: ignore [reportIncompatibleMethodOverride]
-        async def _parent() -> ui.views.BuildInfoView[BotT]:
-            # await self.build.reload()  # TODO: reload() is not implemented
-            build = await self.build.get_persisted_copy()
-            return ui.views.BuildInfoView(build)
-
-        await BuildEditView(self.build, parent=_parent).update(interaction)
+        await BuildEditView(self.build).send(interaction)
 
 
 class EphemeralBuildEditButton[BotT: RedstoneSquid, V: discord.ui.View](discord.ui.Button[V]):

--- a/squid/bot/submission/ui/views.py
+++ b/squid/bot/submission/ui/views.py
@@ -299,6 +299,7 @@ class BuildEditView[BotT: RedstoneSquid](discord.ui.View):
 
     @discord.ui.button(label="Submit", style=discord.ButtonStyle.primary)
     async def submit(self, interaction: discord.Interaction[BotT], button: discord.ui.Button):
+        await interaction.response.defer()
         await self.build.save()
         await interaction.followup.send(
             content="Submitted", embed=await self.get_handler(interaction).generate_embed(), ephemeral=True

--- a/squid/bot/submission/ui/views.py
+++ b/squid/bot/submission/ui/views.py
@@ -177,6 +177,7 @@ class BuildEditView[BotT: RedstoneSquid](discord.ui.View):
 
     This view has no locking guarantees and may fail if the user submits a build that has been locked by another task/thread/process.
     """
+
     def __init__(
         self,
         build: Build,
@@ -231,7 +232,11 @@ class BuildEditView[BotT: RedstoneSquid](discord.ui.View):
 
     def get_modal(self) -> EditModal:
         """Page is 1-indexed"""
-        modal = EditModal(parent=self, title=f"Edit Build (Page {self.page})", timeout=(self.expiry_time - discord.utils.utcnow()).seconds)
+        modal = EditModal(
+            parent=self,
+            title=f"Edit Build (Page {self.page})",
+            timeout=(self.expiry_time - discord.utils.utcnow()).seconds,
+        )
         if 5 * self.page <= len(self.items):
             for i in range(5):
                 base_index = 5 * (self.page - 1)

--- a/squid/bot/submission/ui/views.py
+++ b/squid/bot/submission/ui/views.py
@@ -22,7 +22,7 @@ from squid.bot.submission.ui.components import (
     RecordCategorySelect,
     get_text_input,
 )
-from squid.bot.utils import DEFAULT
+from squid.bot.utils import DEFAULT, DefaultType
 from squid.db.builds import Build
 from squid.db.schema import Category, Status
 
@@ -180,7 +180,7 @@ class BuildEditView[BotT: RedstoneSquid](discord.ui.View):
     def __init__(
         self,
         build: Build,
-        items: Sequence[BuildField] = DEFAULT,
+        items: Sequence[BuildField] | DefaultType = DEFAULT,
         *,
         timeout: float = 300,
     ):

--- a/squid/bot/submission/ui/views.py
+++ b/squid/bot/submission/ui/views.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import datetime
 import re
-from typing import TYPE_CHECKING, Sequence, override
+from typing import TYPE_CHECKING, Sequence, cast, override
 
 import discord
+from discord import Interaction
 
 from squid.bot.submission import ui
 from squid.bot.submission.navigation_view import BaseNavigableView, MaybeAwaitableBaseNavigableViewFunc
@@ -103,6 +105,8 @@ class SubmissionModal(discord.ui.Modal):
 
 
 class EditModal[BotT: RedstoneSquid](discord.ui.Modal):
+    """This is a modal that allows users to edit a build. Exclusively for BuildEditView."""
+
     def __init__(
         self, parent: ui.views.BuildEditView[BotT], title: str, timeout: float | None = 60, custom_id: str | None = None
     ):
@@ -168,15 +172,28 @@ class ConfirmationView(discord.ui.View):
         self.stop()
 
 
-class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
+class BuildEditView[BotT: RedstoneSquid](discord.ui.View):
+    """A view that allows users to edit a build.
+
+    This view has no locking guarantees and may fail if the user submits a build that has been locked by another task/thread/process.
+    """
     def __init__(
         self,
         build: Build,
         items: Sequence[BuildField] = DEFAULT,
         *,
-        parent: BaseNavigableView[BotT] | MaybeAwaitableBaseNavigableViewFunc[BotT] | None = None,
+        timeout: float = 300,
     ):
-        super().__init__(parent=parent, timeout=None)
+        """Initializes the BuildEditView.
+
+        Args:
+            build: The build to edit.
+            items: The items to display in the view.
+            parent: The parent view.
+            timeout: The timeout for the view.
+        """
+        super().__init__(timeout=timeout)
+        self.timeout = cast(float, self.timeout)
         self.build = build
         if items is DEFAULT:
             items = [
@@ -201,10 +218,20 @@ class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
         self.items = items
         self.page = 1
         self._max_pages = len(self.items) // 5 + 1
+        self.expiry_time: datetime.datetime = discord.utils.utcnow() + datetime.timedelta(seconds=self.timeout)
 
-    def get_modal(self) -> discord.ui.Modal:
+    @override
+    async def interaction_check(self, interaction: Interaction[BotT], /) -> bool:  # pyright: ignore [reportIncompatibleMethodOverride]
+        if discord.utils.utcnow() > self.expiry_time:
+            for item in self.children:
+                item.disabled = True  # type: ignore
+            await interaction.followup.send("This edit session has expired. Your edits are not saved.", ephemeral=True)
+            return False
+        return True
+
+    def get_modal(self) -> EditModal:
         """Page is 1-indexed"""
-        modal = EditModal(parent=self, title=f"Edit Build (Page {self.page})", timeout=None)
+        modal = EditModal(parent=self, title=f"Edit Build (Page {self.page})", timeout=(self.expiry_time - discord.utils.utcnow()).seconds)
         if 5 * self.page <= len(self.items):
             for i in range(5):
                 base_index = 5 * (self.page - 1)
@@ -219,7 +246,6 @@ class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
         self.previous_page.disabled = self.page == 1
         self.next_page.disabled = self.page == self._max_pages
 
-    @override
     async def send(self, interaction: discord.Interaction[BotT], ephemeral: bool = False) -> None:
         if not interaction.response.is_done():
             await interaction.response.defer(ephemeral=ephemeral)
@@ -231,7 +257,6 @@ class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
             ephemeral=ephemeral,
         )
 
-    @override
     async def update(self, interaction: discord.Interaction[BotT]):
         self._handle_button_states()
         await interaction.response.edit_message(
@@ -252,7 +277,7 @@ class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
         return discord.Embed(title="Build Summary", description="\n".join(summaries))
 
     @discord.ui.button(label="Open", style=discord.ButtonStyle.primary)
-    async def open(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def open(self, interaction: discord.Interaction[BotT], button: discord.ui.Button):
         await interaction.response.send_modal(self.get_modal())
 
     @discord.ui.button(label="Previous Page", style=discord.ButtonStyle.primary)
@@ -269,7 +294,6 @@ class BuildEditView[BotT: RedstoneSquid](BaseNavigableView[BotT]):
 
     @discord.ui.button(label="Submit", style=discord.ButtonStyle.primary)
     async def submit(self, interaction: discord.Interaction[BotT], button: discord.ui.Button):
-        await self.press_home(interaction)
         await self.build.save()
         await interaction.followup.send(
             content="Submitted", embed=await self.get_handler(interaction).generate_embed(), ephemeral=True

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -880,13 +880,14 @@ class Build:
                 .execute()
             )
         except:
-            vx.disconnect()
             if delete_build_on_error:
                 logger.warning("Failed to save build %s, deleting it", repr(self))
                 await db.table("builds").delete().eq("id", self.id).execute()
             else:
                 logger.error("Failed to update build %s. This means the build is in an inconsistent state.", repr(self))
             raise
+        finally:
+            vx.disconnect()
 
     async def _update_build_subcategory_table(self) -> None:
         """Updates the subcategory table with the given data."""

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -880,7 +880,10 @@ class Build:
         except:
             vx.disconnect()
             if delete_build_on_error:
+                logger.warning("Failed to save build %s, deleting it", repr(self))
                 await db.table("builds").delete().eq("id", self.id).execute()
+            else:
+                logger.error("Failed to update build %s. This means the build is in an inconsistent state.", repr(self))
             raise
 
     async def _update_build_subcategory_table(self) -> None:

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -556,6 +556,8 @@ class Build:
 
     async def try_acquire_lock(self) -> bool:
         """Tries to acquire a lock on the build to prevent concurrent modifications."""
+        if self.id is None:
+            raise ValueError("Cannot lock a build without an ID.")
         response = await DatabaseManager().table("builds").update({"is_locked": True}, count=CountMethod.exact).eq("id", self.id).execute()
         return response.count == 1
 

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -849,7 +849,7 @@ class Build:
             self.id = response.data[0]["id"]
             delete_build_on_error = True
         else:
-            await self.lock.acquire()
+            await self.lock.acquire(timeout=30)
             response = await db.table("builds").update(build_data, count=CountMethod.exact).eq("id", self.id).execute()
             assert response.count == 1
             delete_build_on_error = False

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -1091,6 +1091,7 @@ class BuildLock:
             .table("builds")
             .update({"is_locked": True}, count=CountMethod.exact, returning=ReturnMethod.minimal)
             .eq("id", self.build_id)
+            .eq("is_locked", False)
             .execute()
         )
         if response.count == 1:

--- a/squid/db/builds.py
+++ b/squid/db/builds.py
@@ -1064,6 +1064,7 @@ class Build:
 
 class BuildLock:
     """A reentrant lock to prevent concurrent modifications to a build."""
+
     def __init__(self, build_id: int | None):
         """Initializes the lock
 
@@ -1154,6 +1155,7 @@ class BuildLock:
 
 class LockContextManager:
     """A context manager for BuildLock."""
+
     def __init__(self, lock: BuildLock, *, blocking: bool = True, timeout: float = -1):
         self.lock = lock
         self.blocking = blocking

--- a/squid/db/schema.py
+++ b/squid/db/schema.py
@@ -66,6 +66,8 @@ class BuildRecord(TypedDict):
     version_spec: str
     ai_generated: bool
     embedding: list[float] | None
+    is_locked: bool
+    locked_at: str | None  # timestamptz
 
 
 class MessageRecord(TypedDict):

--- a/supabase/migrations/20250131081045_build_lock.sql
+++ b/supabase/migrations/20250131081045_build_lock.sql
@@ -1,0 +1,16 @@
+alter table builds add column is_locked boolean not null default false;
+alter table builds add column locked_at timestamptz default null;
+
+-- Add trigger to set locked_at when is_locked is set
+create or replace function set_locked_at() returns trigger as $$
+begin
+  if new.is_locked then
+    new.locked_at := now();
+  else
+    new.locked_at := null;
+  end if;
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger set_locked_at before update on builds for each row execute function set_locked_at();


### PR DESCRIPTION
Basically a new `is_locked` column is added to the db. And a lock is implemented to continuously try to set is_locked to True iif is_locked is False. The lock implemented is unique to a build object and thus should be safe even with asyncio.